### PR TITLE
[ADD] Header for Haskell files

### DIFF
--- a/src/main/kotlin/com/epiheader/epiheader/Header.kt
+++ b/src/main/kotlin/com/epiheader/epiheader/Header.kt
@@ -24,6 +24,9 @@ class Header: AnAction() {
             if (type == "c" || type == "cpp" || type == "cc" || type == "h") {
                 header = "/*\n** EPITECH PROJECT, " + year + "\n** " + project!!.name + "\n** File description:\n** " + filename + "\n*/\n"
             }
+            if (type == "hs") {
+                header = "{-\n-- EPITECH PROJECT, " + year + "\n-- " + project!!.name + "\n-- File description:\n-- " + filename + "\n-}\n"
+            }
             if (filename == "Makefile") {
                 header = "##\n## EPITECH PROJECT, " + year + "\n## " + project!!.name + "\n## File description:\n## " + filename + "\n##\n"
             }


### PR DESCRIPTION
As part of the second year pool, Epitech students are required to do Haskell.

Here is a small addition to add the possibility of putting a header on a .hs file (haskell)