### PR TITLE
[ADD] Header for C++ & Name formatting for define of C header

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,11 +1,11 @@
 plugins {
     id("java")
     id("org.jetbrains.kotlin.jvm") version "1.7.10"
-    id("org.jetbrains.intellij") version "1.8.0"
+    id("org.jetbrains.intellij") version "1.12.0"
 }
 
 group = "com.epiheader"
-version = "1.3"
+version = "1.4"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/com/epiheader/epiheader/Header.kt
+++ b/src/main/kotlin/com/epiheader/epiheader/Header.kt
@@ -18,9 +18,11 @@ class Header: AnAction() {
         try {
             val year = LocalDateTime.now().year.toString()
             val type = file!!.extension
-            val filename = file.name
+            val filename = file.name.substring(0, file.name.lastIndexOf('.'))
+            val defineFilename = file.name.uppercase().replace('.', '_') + "_"
+            val className = filename.replaceFirstChar { it.uppercase() }
             var header = ""
-            if (type == "c" || type == "cpp" || type == "cc" || type == "h") {
+            if (type == "c" || type == "cpp" || type == "cc" || type == "h" || type == "hpp" || type == "hh") {
                 header = "/*\n** EPITECH PROJECT, " + year + "\n** " + project!!.name + "\n** File description:\n** " + filename + "\n*/\n"
             }
             if (type == "hs") {
@@ -29,8 +31,13 @@ class Header: AnAction() {
             if (filename == "Makefile") {
                 header = "##\n## EPITECH PROJECT, " + year + "\n## " + project!!.name + "\n## File description:\n## " + filename + "\n##\n"
             }
-            if (type == "h") {
-                header += "#ifndef $filename\n\t#define $filename\n#endif /*$filename*/"
+            if (type == "h" || type == "hh") {
+                header += "#ifndef $defineFilename\n\t#define $defineFilename\n#endif /*$defineFilename*/"
+            }
+            if (type == "hpp") {
+                header += "#ifndef $defineFilename\n\t#define $defineFilename\n"
+                header += "\nclass $className {\n\tpublic:\n\t\t$className();\n\t\t~$className();\n\n\tprotected:\n\tprivate:\n};\n\n"
+                header += "#endif /*$defineFilename*/"
             }
             val text = document.text
             header += text


### PR DESCRIPTION
Hello,

Today I propose a new modification for this plugin.

I just started the CPP and I noticed that the header generation was missing for the CPP headers (whose extension is HPP).
Here is what to add the headers for the CPP.
I also added the generation of a class in addition to the header.
Finally, I also changed the number of the define from header.h to HEADER_H_